### PR TITLE
Milky/selection border

### DIFF
--- a/Mappy/Models/FeatureViewViewModel.cs
+++ b/Mappy/Models/FeatureViewViewModel.cs
@@ -79,7 +79,7 @@
             this.selectCategoryEvent.OnNext(index);
         }
 
-        public void SetSelectedFeature(string featureName)
+        public void SetSelectedItem(string featureName)
         {
             this.dispatcher.SetSelectedFeature(featureName);
         }

--- a/Mappy/Models/FeatureViewViewModel.cs
+++ b/Mappy/Models/FeatureViewViewModel.cs
@@ -27,7 +27,9 @@
 
         private readonly FeatureService featureService;
 
-        public FeatureViewViewModel(FeatureService featureService)
+        private readonly Dispatcher dispatcher;
+
+        public FeatureViewViewModel(FeatureService featureService, Dispatcher dispatcher)
         {
             featureService.FeaturesChanged += this.OnFeaturesChanged;
 
@@ -58,6 +60,7 @@
                 .Subscribe(_ => this.UpdateFeatures());
 
             this.featureService = featureService;
+            this.dispatcher = dispatcher;
         }
 
         public IObservable<ComboBoxViewModel> ComboBox1Model => this.worlds;
@@ -74,6 +77,11 @@
         public void SelectComboBox2Item(int index)
         {
             this.selectCategoryEvent.OnNext(index);
+        }
+
+        public void SetSelectedFeature(string featureName)
+        {
+            this.dispatcher.SetSelectedFeature(featureName);
         }
 
         public void Dispose()

--- a/Mappy/Models/IMapViewViewModel.cs
+++ b/Mappy/Models/IMapViewViewModel.cs
@@ -20,7 +20,9 @@
 
         IObservable<Point> ViewportLocation { get; }
 
-        void MouseDown(Point location);
+        void MouseLeftDown(Point location);
+
+        void MouseRightDown(Point location);
 
         void MouseMove(Point locattion);
 

--- a/Mappy/Models/ISectionViewViewModel.cs
+++ b/Mappy/Models/ISectionViewViewModel.cs
@@ -14,5 +14,7 @@
         void SelectComboBox1Item(int index);
 
         void SelectComboBox2Item(int index);
+
+        void SetSelectedFeature(string featureName);
     }
 }

--- a/Mappy/Models/ISectionViewViewModel.cs
+++ b/Mappy/Models/ISectionViewViewModel.cs
@@ -15,6 +15,6 @@
 
         void SelectComboBox2Item(int index);
 
-        void SetSelectedFeature(string featureName);
+        void SetSelectedItem(string selectedItemName);
     }
 }

--- a/Mappy/Models/MapViewViewModel.cs
+++ b/Mappy/Models/MapViewViewModel.cs
@@ -186,7 +186,7 @@
             this.dispatcher.SetViewportLocation(position);
         }
 
-        public void MouseDown(Point location)
+        public void MouseLeftDown(Point location)
         {
             this.mouseDown = true;
             this.lastMousePos = location;
@@ -204,6 +204,22 @@
                     this.dispatcher.StartBandbox(location.X, location.Y);
                     this.bandboxMode = true;
                 }
+            }
+        }
+
+        public void MouseRightDown(Point location)
+        {
+            this.mouseDown = true;
+            this.lastMousePos = location;
+
+            if (!this.itemsLayer.Value.IsInSelection(location.X, location.Y) &&
+                this.featureService.SelectedFeature != null)
+            {
+                this.dispatcher.DragDropFeature(
+                    this.featureService.SelectedFeature.Name,
+                    location.X,
+                    location.Y
+                );
             }
         }
 

--- a/Mappy/Models/SectionViewViewModel.cs
+++ b/Mappy/Models/SectionViewViewModel.cs
@@ -22,7 +22,9 @@
 
         private readonly SectionService sectionService;
 
-        public SectionViewViewModel(SectionService sectionService)
+        private readonly Dispatcher dispatcher;
+
+        public SectionViewViewModel(SectionService sectionService, Dispatcher dispatcher)
         {
             sectionService.SectionsChanged += this.OnSectionsChanged;
 
@@ -44,6 +46,7 @@
                     });
 
             this.sectionService = sectionService;
+            this.dispatcher = dispatcher;
         }
 
         public IObservable<ComboBoxViewModel> ComboBox1Model => this.worlds;
@@ -106,6 +109,11 @@
             this.UpdateWorlds();
             this.UpdateCategories();
             this.UpdateSections();
+        }
+
+        public void SetSelectedFeature(string featureName)
+        {
+            this.dispatcher.SetSelectedFeature(featureName);
         }
     }
 }

--- a/Mappy/Models/SectionViewViewModel.cs
+++ b/Mappy/Models/SectionViewViewModel.cs
@@ -65,6 +65,11 @@
             this.selectCategoryEvent.OnNext(index);
         }
 
+        public void SetSelectedFeature(string featureName)
+        {
+            this.dispatcher.SetSelectedFeature(featureName);
+        }
+
         public void Dispose()
         {
             this.worlds.Dispose();
@@ -109,11 +114,6 @@
             this.UpdateWorlds();
             this.UpdateCategories();
             this.UpdateSections();
-        }
-
-        public void SetSelectedFeature(string featureName)
-        {
-            this.dispatcher.SetSelectedFeature(featureName);
         }
     }
 }

--- a/Mappy/Models/SectionViewViewModel.cs
+++ b/Mappy/Models/SectionViewViewModel.cs
@@ -65,9 +65,9 @@
             this.selectCategoryEvent.OnNext(index);
         }
 
-        public void SetSelectedFeature(string featureName)
+        public void SetSelectedItem(string sectionName)
         {
-            this.dispatcher.SetSelectedFeature(featureName);
+            // this.dispatcher.SetSelectedSection(sectionName);
         }
 
         public void Dispose()

--- a/Mappy/Program.cs
+++ b/Mappy/Program.cs
@@ -67,8 +67,8 @@
                 tileCache);
             mainForm.SetModel(new MainFormViewModel(model, dispatcher, featureService));
 
-            mainForm.SectionView.SetModel(new SectionViewViewModel(sectionsService));
-            mainForm.FeatureView.SetModel(new FeatureViewViewModel(featureService));
+            mainForm.SectionView.SetModel(new SectionViewViewModel(sectionsService, dispatcher));
+            mainForm.FeatureView.SetModel(new FeatureViewViewModel(featureService, dispatcher));
 
             mainForm.MapViewPanel.SetModel(new MapViewViewModel(model, dispatcher, featureService));
 

--- a/Mappy/Services/Dispatcher.cs
+++ b/Mappy/Services/Dispatcher.cs
@@ -545,6 +545,15 @@
             this.model.Map.IfSome(x => x.SelectStartPosition(index));
         }
 
+        public void SetSelectedFeature(string featureName)
+        {
+            var featureFromTag = this.featureService.TryGetFeature(featureName);
+            if (featureFromTag.HasValue)
+            {
+                this.featureService.SelectedFeature = featureFromTag.UnsafeValue;
+            }
+        }
+
         private static IEnumerable<string> GetMapNames(HpiArchive hpi)
         {
             return hpi.GetFiles("maps")

--- a/Mappy/Services/FeatureService.cs
+++ b/Mappy/Services/FeatureService.cs
@@ -30,6 +30,8 @@
 
         public event EventHandler FeaturesChanged;
 
+        public Feature SelectedFeature { get; set; }
+
         public void AddFeatures(IEnumerable<FeatureInfo> features)
         {
             foreach (var f in features)
@@ -88,31 +90,31 @@
 
         private static OffsetBitmap LoadBitmap(GafEntry[] gaf, string sequenceName)
         {
-                var entry = gaf.FirstOrDefault(
-                    x => string.Equals(x.Name, sequenceName, StringComparison.OrdinalIgnoreCase));
-                if (entry == null)
-                {
-                    // skip if the sequence is not in this gaf file
-                    return null;
-                }
+            var entry = gaf.FirstOrDefault(
+                x => string.Equals(x.Name, sequenceName, StringComparison.OrdinalIgnoreCase));
+            if (entry == null)
+            {
+                // skip if the sequence is not in this gaf file
+                return null;
+            }
 
-                var frame = entry.Frames[0];
+            var frame = entry.Frames[0];
 
-                Bitmap bmp;
-                if (frame.Data == null || frame.Width == 0 || frame.Height == 0)
-                {
-                    bmp = new Bitmap(50, 50);
-                }
-                else
-                {
-                    bmp = BitmapConvert.ToBitmap(
-                        frame.Data,
-                        frame.Width,
-                        frame.Height,
-                        frame.TransparencyIndex);
-                }
+            Bitmap bmp;
+            if (frame.Data == null || frame.Width == 0 || frame.Height == 0)
+            {
+                bmp = new Bitmap(50, 50);
+            }
+            else
+            {
+                bmp = BitmapConvert.ToBitmap(
+                    frame.Data,
+                    frame.Width,
+                    frame.Height,
+                    frame.TransparencyIndex);
+            }
 
-                return new OffsetBitmap(-frame.OffsetX, -frame.OffsetY, bmp);
+            return new OffsetBitmap(-frame.OffsetX, -frame.OffsetY, bmp);
         }
 
         private static GafEntry[] LoadGafEntries(HpiArchive.FileInfo fileInfo, HpiArchive archive)
@@ -193,16 +195,16 @@
                         }
 
                         var f = new Feature
-                            {
-                                Name = item.Value.Name,
-                                World = item.Value.World,
-                                Category = item.Value.Category,
-                                Footprint = item.Value.Footprint,
-                                Image = bitmap.Bitmap,
-                                Offset = new Point(-bitmap.OffsetX, -bitmap.OffsetY),
-                                ReclaimInfo = item.Value.ReclaimInfo,
-                                Permanent = item.Value.Permanent,
-                            };
+                        {
+                            Name = item.Value.Name,
+                            World = item.Value.World,
+                            Category = item.Value.Category,
+                            Footprint = item.Value.Footprint,
+                            Image = bitmap.Bitmap,
+                            Offset = new Point(-bitmap.OffsetX, -bitmap.OffsetY),
+                            ReclaimInfo = item.Value.ReclaimInfo,
+                            Permanent = item.Value.Permanent,
+                        };
                         this.featureCache.Add(item.Key, f);
                         yield return f;
                     }
@@ -220,16 +222,16 @@
                     var bitmap = LoadRenderFile(archive, objectFile);
 
                     var f = new Feature
-                        {
-                            Name = entry.Value.Name,
-                            World = entry.Value.World,
-                            Category = entry.Value.Category,
-                            Footprint = entry.Value.Footprint,
-                            Image = bitmap.Bitmap,
-                            Offset = new Point(-bitmap.OffsetX, -bitmap.OffsetY),
-                            ReclaimInfo = entry.Value.ReclaimInfo,
-                            Permanent = entry.Value.Permanent,
-                        };
+                    {
+                        Name = entry.Value.Name,
+                        World = entry.Value.World,
+                        Category = entry.Value.Category,
+                        Footprint = entry.Value.Footprint,
+                        Image = bitmap.Bitmap,
+                        Offset = new Point(-bitmap.OffsetX, -bitmap.OffsetY),
+                        ReclaimInfo = entry.Value.ReclaimInfo,
+                        Permanent = entry.Value.Permanent,
+                    };
                     this.featureCache.Add(entry.Key, f);
                     yield return f;
                 }

--- a/Mappy/UI/Controls/DoubleComboListView.Designer.cs
+++ b/Mappy/UI/Controls/DoubleComboListView.Designer.cs
@@ -40,9 +40,9 @@
             this.comboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBox1.FormattingEnabled = true;
             this.comboBox1.Location = new System.Drawing.Point(0, 0);
-            this.comboBox1.Margin = new System.Windows.Forms.Padding(0, 0, 0, 3);
+            this.comboBox1.Margin = new System.Windows.Forms.Padding(0, 0, 0, 5);
             this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(177, 21);
+            this.comboBox1.Size = new System.Drawing.Size(264, 28);
             this.comboBox1.TabIndex = 0;
             // 
             // comboBox2
@@ -51,9 +51,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBox2.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBox2.FormattingEnabled = true;
-            this.comboBox2.Location = new System.Drawing.Point(0, 27);
+            this.comboBox2.Location = new System.Drawing.Point(0, 42);
+            this.comboBox2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.comboBox2.Name = "comboBox2";
-            this.comboBox2.Size = new System.Drawing.Size(177, 21);
+            this.comboBox2.Size = new System.Drawing.Size(264, 28);
             this.comboBox2.TabIndex = 1;
             // 
             // listView1
@@ -61,21 +62,28 @@
             this.listView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.listView1.Location = new System.Drawing.Point(0, 54);
+            this.listView1.HideSelection = false;
+            this.listView1.Location = new System.Drawing.Point(0, 83);
+            this.listView1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.listView1.MultiSelect = false;
             this.listView1.Name = "listView1";
-            this.listView1.Size = new System.Drawing.Size(177, 300);
+            this.listView1.OwnerDraw = true;
+            this.listView1.Size = new System.Drawing.Size(264, 459);
             this.listView1.TabIndex = 2;
             this.listView1.UseCompatibleStateImageBehavior = false;
+            this.listView1.DrawItem += new System.Windows.Forms.DrawListViewItemEventHandler(this.ListView1_DrawItem);
+            this.listView1.DrawSubItem += new System.Windows.Forms.DrawListViewSubItemEventHandler(this.ListView1_DrawSubItem);
             // 
             // DoubleComboListView
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.listView1);
             this.Controls.Add(this.comboBox2);
             this.Controls.Add(this.comboBox1);
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "DoubleComboListView";
-            this.Size = new System.Drawing.Size(177, 354);
+            this.Size = new System.Drawing.Size(266, 545);
             this.ResumeLayout(false);
 
         }

--- a/Mappy/UI/Controls/DoubleComboListView.Designer.cs
+++ b/Mappy/UI/Controls/DoubleComboListView.Designer.cs
@@ -73,6 +73,7 @@
             this.listView1.UseCompatibleStateImageBehavior = false;
             this.listView1.DrawItem += new System.Windows.Forms.DrawListViewItemEventHandler(this.ListView1_DrawItem);
             this.listView1.DrawSubItem += new System.Windows.Forms.DrawListViewSubItemEventHandler(this.ListView1_DrawSubItem);
+            this.listView1.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.ListView1_ItemSelectionChanged);
             // 
             // DoubleComboListView
             // 

--- a/Mappy/UI/Controls/DoubleComboListView.cs
+++ b/Mappy/UI/Controls/DoubleComboListView.cs
@@ -1,5 +1,6 @@
 ﻿namespace Mappy.UI.Controls
 {
+    using System.Drawing;
     using System.Windows.Forms;
 
     public partial class DoubleComboListView : UserControl
@@ -14,5 +15,19 @@
         public ComboBox ComboBox2 => this.comboBox2;
 
         public ListView ListView => this.listView1;
+
+        private void ListView1_DrawSubItem(object sender, DrawListViewSubItemEventArgs e)
+        {
+            e.DrawDefault = true;
+        }
+
+        private void ListView1_DrawItem(object sender, DrawListViewItemEventArgs e)
+        {
+            e.DrawDefault = true;
+            if (e.Item.Selected)
+            {
+                e.Graphics.DrawRectangle(Pens.Red, e.Bounds);
+            }
+        }
     }
 }

--- a/Mappy/UI/Controls/DoubleComboListView.cs
+++ b/Mappy/UI/Controls/DoubleComboListView.cs
@@ -5,9 +5,16 @@
 
     public partial class DoubleComboListView : UserControl
     {
+        private readonly Pen selectionPen;
+        private readonly Pen defaultPen;
+
+        private ListViewItem previousSelection;
+
         public DoubleComboListView()
         {
             this.InitializeComponent();
+            this.selectionPen = new Pen(Color.Red, 3);
+            this.defaultPen = new Pen(Color.White, 3);
         }
 
         public ComboBox ComboBox1 => this.comboBox1;
@@ -26,7 +33,17 @@
             e.DrawDefault = true;
             if (e.Item.Selected)
             {
-                e.Graphics.DrawRectangle(Pens.Red, e.Bounds);
+                e.Graphics.DrawRectangle(this.selectionPen, e.Bounds);
+                this.previousSelection = e.Item;
+            }
+            else if (sender is ListView && ((ListView)sender).SelectedItems.Count <= 0 &&
+                this.previousSelection != null && this.previousSelection.Index == e.Item.Index)
+            {
+                e.Graphics.DrawRectangle(this.selectionPen, this.previousSelection.Bounds);
+            }
+            else
+            {
+                e.Graphics.DrawRectangle(this.defaultPen, e.Bounds);
             }
         }
     }

--- a/Mappy/UI/Controls/DoubleComboListView.cs
+++ b/Mappy/UI/Controls/DoubleComboListView.cs
@@ -46,5 +46,10 @@
                 e.Graphics.DrawRectangle(this.defaultPen, e.Bounds);
             }
         }
+
+        private void ListView1_ItemSelectionChanged(object sender, ListViewItemSelectionChangedEventArgs e)
+        {
+            this.ListView.Refresh();
+        }
     }
 }

--- a/Mappy/UI/Controls/MapViewPanel.cs
+++ b/Mappy/UI/Controls/MapViewPanel.cs
@@ -44,7 +44,14 @@
         private void MapViewMouseDown(object sender, MouseEventArgs e)
         {
             var loc = this.mapView.ToVirtualPoint(e.Location);
-            this.model.MouseDown(loc);
+            if (e.Button == MouseButtons.Left)
+            {
+                this.model.MouseLeftDown(loc);
+            }
+            else if (e.Button == MouseButtons.Right)
+            {
+                this.model.MouseRightDown(loc);
+            }
         }
 
         private void MapViewMouseMove(object sender, MouseEventArgs e)

--- a/Mappy/UI/Controls/SectionView.cs
+++ b/Mappy/UI/Controls/SectionView.cs
@@ -161,7 +161,7 @@
                 this.UpdateItemDeselected(view.Items[this.previousSelection.Index]);
                 this.UpdateItemSelected(view.Items[selItem.Index]);
                 this.previousSelection = selItem;
-                this.model.SetSelectedFeature(selItem.Text);
+                this.model.SetSelectedItem(selItem.Text);
             }
 
             view.ItemSelectionChanged += this.ListViewItemSelectionChanged;

--- a/Mappy/UI/Controls/SectionView.cs
+++ b/Mappy/UI/Controls/SectionView.cs
@@ -18,6 +18,8 @@
         private bool suppressCombo1SelectedItemEvents;
         private bool suppressCombo2SelectedItemEvents;
 
+        private ListViewItem previousSelection;
+
         public SectionView()
         {
             this.InitializeComponent();
@@ -25,6 +27,7 @@
             this.control.ComboBox1.SelectedIndexChanged += this.ComboBox1SelectedIndexChanged;
             this.control.ComboBox2.SelectedIndexChanged += this.ComboBox2SelectedIndexChanged;
             this.control.ListView.ItemDrag += this.ListViewItemDrag;
+            this.control.ListView.SelectedIndexChanged += this.ListViewItemSelectionChanged;
         }
 
         public Size ImageSize { get; set; } = new Size(128, 128);
@@ -133,6 +136,53 @@
 
             var data = view.SelectedItems[0].Tag;
             view.DoDragDrop(data, DragDropEffects.Copy);
+        }
+
+        private void ListViewItemSelectionChanged(object sender, EventArgs e)
+        {
+            var view = (ListView)sender;
+            if (view.SelectedItems.Count == 0)
+            {
+                return;
+            }
+
+            view.ItemSelectionChanged -= this.ListViewItemSelectionChanged;
+            var selItem = view.SelectedItems[0];
+
+            if (this.previousSelection == null ||
+                this.previousSelection.Index < 0 ||
+                view.Items[this.previousSelection.Index] == null)
+            {
+                this.previousSelection = selItem;
+            }
+
+            if (selItem != this.previousSelection)
+            {
+                this.UpdateItemDeselected(view.Items[this.previousSelection.Index]);
+                this.UpdateItemSelected(view.Items[selItem.Index]);
+                this.previousSelection = selItem;
+                this.model.SetSelectedFeature(selItem.Text);
+            }
+
+            view.ItemSelectionChanged += this.ListViewItemSelectionChanged;
+        }
+
+        private void UpdateItemSelected(ListViewItem toBeSelected)
+        {
+            // Functionality
+            toBeSelected.Selected = true;
+
+            // Appearance
+            toBeSelected.BackColor = Color.Orange;
+            toBeSelected.ForeColor = Color.Black;
+        }
+
+        private void UpdateItemDeselected(ListViewItem toBeSelected)
+        {
+            toBeSelected.Selected = false;
+
+            toBeSelected.BackColor = Color.White;
+            toBeSelected.ForeColor = Color.Black;
         }
     }
 }

--- a/Mappy/UI/Controls/SectionView.cs
+++ b/Mappy/UI/Controls/SectionView.cs
@@ -154,37 +154,19 @@
                 view.Items[this.previousSelection.Index] == null)
             {
                 this.previousSelection = selItem;
-                this.UpdateItemSelected(view.Items[selItem.Index]);
+                view.Items[selItem.Index].Selected = true;
                 this.model.SetSelectedItem(selItem.Text);
             }
 
             if (selItem != this.previousSelection)
             {
-                this.UpdateItemDeselected(view.Items[this.previousSelection.Index]);
-                this.UpdateItemSelected(view.Items[selItem.Index]);
+                view.Items[this.previousSelection.Index].Selected = false;
+                view.Items[selItem.Index].Selected = true;
                 this.previousSelection = selItem;
                 this.model.SetSelectedItem(selItem.Text);
             }
 
             view.ItemSelectionChanged += this.ListViewItemSelectionChanged;
-        }
-
-        private void UpdateItemSelected(ListViewItem toBeSelected)
-        {
-            // Functionality
-            toBeSelected.Selected = true;
-
-            // Appearance
-            toBeSelected.BackColor = Color.Orange;
-            toBeSelected.ForeColor = Color.Black;
-        }
-
-        private void UpdateItemDeselected(ListViewItem toBeSelected)
-        {
-            toBeSelected.Selected = false;
-
-            toBeSelected.BackColor = Color.White;
-            toBeSelected.ForeColor = Color.Black;
         }
     }
 }

--- a/Mappy/UI/Controls/SectionView.cs
+++ b/Mappy/UI/Controls/SectionView.cs
@@ -154,6 +154,8 @@
                 view.Items[this.previousSelection.Index] == null)
             {
                 this.previousSelection = selItem;
+                this.UpdateItemSelected(view.Items[selItem.Index]);
+                this.model.SetSelectedItem(selItem.Text);
             }
 
             if (selItem != this.previousSelection)


### PR DESCRIPTION
Add 2 features:

### Right-Click Places Last Selected Feature
While the actual placement functionality already exists in `dispatcher.DragDropFeature()`, the functionality around storing the last selected feature was not present. Also split the generic mouse-down event into mouse-left/mouse-right.

Functional Requirements:
- Right-Clicking after loading up Mappy initially, that is without any feature being selected, does nothing. This includes not crashing.
- Right-Clicking when the user has selected a feature places the selected feature at the mouse location.
- Changing the feature selection correctly changes the feature that is placed on Right-Click.

### DoubleCombo Selection Border
To enable the user to easily see what item in the ListView is selected a thick red border was added. The actual appearance of the border matters little, the main thing is that the user can easily identify what is selected even when the ListView is not in focus.

Functional Requirements:
- Selecting a Section from the Section-List places a thick, red border around that Section.
- Selecting a Feature from the Feature-List places a thick, red border around that Feature.
- Selecting a Feature has no impact on a Section, or vice-versa.
- The thick red border is painted behind the image and/or the text of the item being selected.
- Changing selection within the list correctly removes the old selection border and repaints the border on the correct selected item.
- The red border stays visible when the list, or any part of the side panel, isn't in focus.

<img width="488" alt="BorderSelection" src="https://user-images.githubusercontent.com/9074205/171625927-5ae3f7b0-8a07-4782-bb1a-77c82325a3d3.png">
