### PR TITLE
Milky/multi feature copypaste

### DIFF
--- a/Mappy/Mappy.csproj
+++ b/Mappy/Mappy.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Models\BandboxMode.cs" />
     <Compile Include="Models\ComboBoxViewModel.cs" />
     <Compile Include="Models\CoreModel.cs" />
+    <Compile Include="Models\Enums\GUITab.cs" />
     <Compile Include="Models\FeatureClipboardRecord.cs" />
     <Compile Include="Models\FeatureInstance.cs" />
     <Compile Include="Models\FeatureInstanceEventArgs.cs" />

--- a/Mappy/Mappy.csproj
+++ b/Mappy/Mappy.csproj
@@ -152,6 +152,7 @@
     <Compile Include="IO\SectionLoadingUtils.cs" />
     <Compile Include="MappySettings.cs" />
     <Compile Include="Maybe.cs" />
+    <Compile Include="Models\BandboxBehaviours\FreeBandboxBehaviour.cs" />
     <Compile Include="Models\BandboxBehaviours\IBandboxBehaviour.cs" />
     <Compile Include="Models\BandboxBehaviours\IBandboxModel.cs" />
     <Compile Include="Models\BandboxBehaviours\TileBandboxBehaviour.cs" />

--- a/Mappy/Models/BandboxBehaviours/FreeBandboxBehaviour.cs
+++ b/Mappy/Models/BandboxBehaviours/FreeBandboxBehaviour.cs
@@ -1,0 +1,88 @@
+﻿namespace Mappy.Models.BandboxBehaviours
+{
+    using System;
+    using System.Drawing;
+
+    using Mappy.Util;
+
+    /// <summary>
+    /// Defines a free-form bandbox behaviour.
+    /// In this mode, dragging out a bandbox selects features within an
+    /// area of the map
+    /// </summary>
+    public class FreeBandboxBehaviour : Notifier, IBandboxBehaviour
+    {
+        private readonly IBandboxModel model;
+
+        private Rectangle bandboxRectangle;
+
+        private Point startPoint;
+
+        private Point finishPoint;
+
+        public FreeBandboxBehaviour(IBandboxModel model)
+        {
+            this.model = model;
+        }
+
+        public Rectangle BandboxRectangle
+        {
+            get => this.bandboxRectangle;
+            private set => this.SetField(ref this.bandboxRectangle, value, nameof(this.BandboxRectangle));
+        }
+
+        public void StartBandbox(int x, int y)
+        {
+            var p = new Point(x, y);
+            this.startPoint = p;
+            this.finishPoint = p;
+            this.UpdateBandboxRectangle();
+        }
+
+        public void GrowBandbox(int x, int y)
+        {
+            this.finishPoint.X = x;
+            this.finishPoint.Y = y;
+
+            this.UpdateBandboxRectangle();
+        }
+
+        public void CommitBandbox()
+        {
+            try
+            {
+                var width = this.BandboxRectangle.Width;
+                var height = this.BandboxRectangle.Height;
+
+                if (width == 0 || height == 0)
+                {
+                    return;
+                }
+
+                this.model.LiftAndSelectArea(
+                    this.BandboxRectangle.X,
+                    this.BandboxRectangle.Y,
+                    this.BandboxRectangle.Width,
+                    this.bandboxRectangle.Height);
+            }
+            finally
+            {
+                this.BandboxRectangle = Rectangle.Empty;
+            }
+        }
+
+        private void UpdateBandboxRectangle()
+        {
+            var minX = Math.Min(this.startPoint.X, this.finishPoint.X);
+            var minY = Math.Min(this.startPoint.Y, this.finishPoint.Y);
+
+            var maxX = Math.Max(this.startPoint.X, this.finishPoint.X);
+            var maxY = Math.Max(this.startPoint.Y, this.finishPoint.Y);
+
+            var width = maxX - minX;
+            var height = maxY - minY;
+
+            this.BandboxRectangle = new Rectangle(minX, minY, width, height);
+        }
+    }
+}

--- a/Mappy/Models/BandboxBehaviours/FreeBandboxBehaviour.cs
+++ b/Mappy/Models/BandboxBehaviours/FreeBandboxBehaviour.cs
@@ -58,12 +58,12 @@
                 {
                     return;
                 }
-                /*
+
                 this.model.LiftAndSelectArea(
                     this.BandboxRectangle.X,
                     this.BandboxRectangle.Y,
                     this.BandboxRectangle.Width,
-                    this.bandboxRectangle.Height);*/
+                    this.bandboxRectangle.Height);
             }
             finally
             {

--- a/Mappy/Models/BandboxBehaviours/FreeBandboxBehaviour.cs
+++ b/Mappy/Models/BandboxBehaviours/FreeBandboxBehaviour.cs
@@ -41,8 +41,8 @@
 
         public void GrowBandbox(int x, int y)
         {
-            this.finishPoint.X = x;
-            this.finishPoint.Y = y;
+            this.finishPoint.X += x;
+            this.finishPoint.Y += y;
 
             this.UpdateBandboxRectangle();
         }
@@ -58,12 +58,12 @@
                 {
                     return;
                 }
-
+                /*
                 this.model.LiftAndSelectArea(
                     this.BandboxRectangle.X,
                     this.BandboxRectangle.Y,
                     this.BandboxRectangle.Width,
-                    this.bandboxRectangle.Height);
+                    this.bandboxRectangle.Height);*/
             }
             finally
             {

--- a/Mappy/Models/CoreModel.cs
+++ b/Mappy/Models/CoreModel.cs
@@ -1,8 +1,7 @@
 ﻿namespace Mappy.Models
 {
-    using System.ComponentModel;
     using System.Drawing;
-
+    using Mappy.Models.Enums;
     using Mappy.Util;
 
     public class CoreModel : Notifier, IReadOnlyApplicationModel
@@ -19,6 +18,8 @@
         private bool gridVisible;
         private Size gridSize = new Size(16, 16);
         private Color gridColor = MappySettings.Settings.GridColor;
+
+        private GUITab guiTab = GUITab.Sections;
 
         private int viewportWidth;
         private int viewportHeight;
@@ -91,6 +92,15 @@
                 MappySettings.Settings.GridColor = value;
                 MappySettings.SaveSettings();
                 this.SetField(ref this.gridColor, value, nameof(this.GridColor));
+            }
+        }
+
+        public GUITab SelectedGUITab
+        {
+            get => this.guiTab;
+            set
+            {
+                this.SetField(ref this.guiTab, value, nameof(this.SelectedGUITab));
             }
         }
 

--- a/Mappy/Models/Enums/GUITab.cs
+++ b/Mappy/Models/Enums/GUITab.cs
@@ -5,6 +5,7 @@
         Sections,
         Features,
         Starts,
-        Attributes
+        Attributes,
+        Other
     }
 }

--- a/Mappy/Models/Enums/GUITab.cs
+++ b/Mappy/Models/Enums/GUITab.cs
@@ -1,0 +1,10 @@
+﻿namespace Mappy.Models.Enums
+{
+    public enum GUITab
+    {
+        Sections,
+        Features,
+        Starts,
+        Attributes
+    }
+}

--- a/Mappy/Models/FeatureClipboardRecord.cs
+++ b/Mappy/Models/FeatureClipboardRecord.cs
@@ -10,6 +10,17 @@
             this.FeatureName = featureName;
         }
 
+        public FeatureClipboardRecord(string featureName, int viewPortOffsetX, int viewPortOffsetY)
+        {
+            this.FeatureName = featureName;
+            this.VPOffsetX = viewPortOffsetX;
+            this.VPOffsetY = viewPortOffsetY;
+        }
+
         public string FeatureName { get; set; }
+
+        public int VPOffsetX { get; set; }
+
+        public int VPOffsetY { get; set; }
     }
 }

--- a/Mappy/Models/FeatureInstance.cs
+++ b/Mappy/Models/FeatureInstance.cs
@@ -1,11 +1,21 @@
 ﻿namespace Mappy.Models
 {
     using System;
-
+    using System.Drawing;
     using Mappy.Collections;
+    using Mappy.Data;
+    using Mappy.Services;
 
     public sealed class FeatureInstance
     {
+        private static readonly Feature DefaultFeatureRecord = new Feature
+        {
+            Name = "default",
+            Offset = new Point(0, 0),
+            Footprint = new Size(1, 1),
+            Image = Mappy.Properties.Resources.nofeature
+        };
+
         public FeatureInstance(Guid id, string featureName, int x, int y)
             : this(id, featureName, new GridCoordinates(x, y))
         {
@@ -16,9 +26,14 @@
             this.Id = id;
             this.FeatureName = featureName;
             this.Location = location;
+            this.BaseFeature = FeatureService.TryGetFeature(featureName).Or(DefaultFeatureRecord);
         }
 
+        public static FeatureService FeatureService { get; set; }
+
         public Guid Id { get; }
+
+        public Feature BaseFeature { get; }
 
         public string FeatureName { get; }
 

--- a/Mappy/Models/IMainFormViewModel.cs
+++ b/Mappy/Models/IMainFormViewModel.cs
@@ -132,5 +132,7 @@
         void ImportCustomSectionMenuItemClick();
 
         void Load();
+
+        void ChangeSelectedTab();
     }
 }

--- a/Mappy/Models/IMainFormViewModel.cs
+++ b/Mappy/Models/IMainFormViewModel.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Drawing;
+    using Mappy.Models.Enums;
 
     public interface IMainFormViewModel
     {
@@ -133,6 +134,6 @@
 
         void Load();
 
-        void ChangeSelectedTab();
+        void ChangeSelectedTabType(GUITab tabType);
     }
 }

--- a/Mappy/Models/IMapModel.cs
+++ b/Mappy/Models/IMapModel.cs
@@ -1,6 +1,7 @@
 ﻿namespace Mappy.Models
 {
     using System;
+    using System.Collections.Generic;
     using System.Drawing;
 
     public interface IMapModel : IReadOnlyMapModel
@@ -25,6 +26,15 @@
         /// </summary>
         /// <param name="instance">The instance to update.</param>
         void UpdateFeatureInstance(FeatureInstance instance);
+
+        /// <summary>
+        /// Updates the given instance in the collection,
+        /// replacing the existing instance with the same ID.
+        /// If the ID is not present already, an exception is raised.
+        /// </summary>
+        /// <param name="instance">The instance to update.</param>
+        /// <param name="otherUpdatingFeatures">The list of FeatureInstance GUIDs that are being updated</param>
+        void UpdateFeatureInstanceInBatch(FeatureInstance instance, ISet<Guid> otherUpdatingFeatures);
 
         /// <summary>
         /// Removes the feature instance with the given ID.

--- a/Mappy/Models/IReadOnlyApplicationModel.cs
+++ b/Mappy/Models/IReadOnlyApplicationModel.cs
@@ -28,6 +28,6 @@
 
         Color GridColor { get; }
 
-        GUITab GUITab { get; }
+        GUITab SelectedGUITab { get; }
     }
 }

--- a/Mappy/Models/IReadOnlyApplicationModel.cs
+++ b/Mappy/Models/IReadOnlyApplicationModel.cs
@@ -2,6 +2,7 @@
 {
     using System.ComponentModel;
     using System.Drawing;
+    using Mappy.Models.Enums;
 
     public interface IReadOnlyApplicationModel : INotifyPropertyChanged
     {
@@ -26,5 +27,7 @@
         Size GridSize { get; }
 
         Color GridColor { get; }
+
+        GUITab GUITab { get; }
     }
 }

--- a/Mappy/Models/MainFormViewModel.cs
+++ b/Mappy/Models/MainFormViewModel.cs
@@ -4,7 +4,7 @@
     using System.Drawing;
     using System.Linq;
     using System.Reactive.Linq;
-
+    using Mappy.Models.Enums;
     using Mappy.Services;
 
     public class MainFormViewModel : IMainFormViewModel
@@ -342,9 +342,9 @@
             this.dispatcher.Initialize();
         }
 
-        public void ChangeSelectedTab()
+        public void ChangeSelectedTabType(GUITab tabType)
         {
-            this.dispatcher.ChangeSelectedTab();
+            this.dispatcher.ChangeSelectedTab(tabType);
         }
     }
 }

--- a/Mappy/Models/MainFormViewModel.cs
+++ b/Mappy/Models/MainFormViewModel.cs
@@ -341,5 +341,10 @@
         {
             this.dispatcher.Initialize();
         }
+
+        public void ChangeSelectedTab()
+        {
+            this.dispatcher.ChangeSelectedTab();
+        }
     }
 }

--- a/Mappy/Models/UndoableMapModel.cs
+++ b/Mappy/Models/UndoableMapModel.cs
@@ -297,7 +297,7 @@
             return this.model.EnumerateFeatureInstances();
         }
 
-        public void DragDropFeature(string name, int x, int y)
+        public void DragDropFeature(string name, int x, int y, bool deselect = true)
         {
             var featurePos = this.ScreenToHeightIndex(x, y);
             if (featurePos.HasValue && !this.HasFeatureInstanceAt(featurePos.Value.X, featurePos.Value.Y))
@@ -305,11 +305,21 @@
                 var inst = new FeatureInstance(Guid.NewGuid(), name, featurePos.Value.X, featurePos.Value.Y);
                 var addOp = new AddFeatureOperation(this.model, inst);
                 var selectOp = new SelectFeatureOperation(this.model, inst.Id);
-                var op = new CompositeOperation(
-                    OperationFactory.CreateDeselectAndMergeOperation(this.model),
-                    addOp,
-                    selectOp);
-                this.undoManager.Execute(op);
+                if (deselect)
+                {
+                    var op = new CompositeOperation(
+                        OperationFactory.CreateDeselectAndMergeOperation(this.model),
+                        addOp,
+                        selectOp);
+                    this.undoManager.Execute(op);
+                }
+                else
+                {
+                    var op = new CompositeOperation(
+                        addOp,
+                        selectOp);
+                    this.undoManager.Execute(op);
+                }
             }
         }
 

--- a/Mappy/Models/UndoableMapModel.cs
+++ b/Mappy/Models/UndoableMapModel.cs
@@ -24,7 +24,6 @@
 
         private readonly IBandboxBehaviour freeBandboxBehaviour;
 
-
         private readonly ISelectionModel model;
 
         private IBandboxBehaviour currentBandboxBehaviour;
@@ -452,9 +451,16 @@
                 var loc1 = new Point(x, y);
                 var loc2 = new Point(x + width, y + height);
 
-                var validItems = this.EnumerateFeatureInstances().Where(i =>
-                                    ((i.X * 16) >= loc1.X && (i.Y * 16) >= loc1.Y) &&
-                                    ((i.X * 16) <= loc2.X && (i.Y * 16) <= loc2.Y)).ToList();
+                var validItems = new List<FeatureInstance>();
+                foreach (var f in this.EnumerateFeatureInstances())
+                {
+                    var bounds = f.BaseFeature.GetDrawBounds(this.BaseTile.HeightGrid, f.X, f.Y);
+                    if ((bounds.X + (bounds.Width * 0.5)) >= loc1.X && (bounds.Y + (bounds.Height * 0.5)) >= loc1.Y &&
+                        (bounds.X + (bounds.Width * 0.5)) <= loc2.X && (bounds.Y + (bounds.Height * 0.5)) <= loc2.Y)
+                    {
+                        validItems.Add(f);
+                    }
+                }
 
                 List<IReplayableOperation> selections = new List<IReplayableOperation>();
                 for (int i = 0; i < validItems.Count(); i++)

--- a/Mappy/Models/UndoableMapModel.cs
+++ b/Mappy/Models/UndoableMapModel.cs
@@ -641,8 +641,8 @@
                     return false;
                 }
 
-                var isBlocked = !coordSet.Contains(translatedPoint)
-                    && this.HasFeatureInstanceAt(translatedPoint.X, translatedPoint.Y);
+                var isBlocked = // !coordSet.Contains(translatedPoint) &&
+                    this.HasFeatureInstanceAt(translatedPoint.X, translatedPoint.Y);
                 if (isBlocked)
                 {
                     return false;

--- a/Mappy/Models/UndoableMapModel.cs
+++ b/Mappy/Models/UndoableMapModel.cs
@@ -641,7 +641,7 @@
                     return false;
                 }
 
-                var isBlocked = // !coordSet.Contains(translatedPoint) &&
+                var isBlocked = !coordSet.Contains(translatedPoint) &&
                     this.HasFeatureInstanceAt(translatedPoint.X, translatedPoint.Y);
                 if (isBlocked)
                 {

--- a/Mappy/Operations/BatchMoveFeatureOperation.cs
+++ b/Mappy/Operations/BatchMoveFeatureOperation.cs
@@ -29,13 +29,10 @@
 
         public void Execute()
         {
-            // BUG: this assumes that the destination of any feature
-            //      does not contain another feature
-            //      that is also about to be moved.
             foreach (var id in this.ids)
             {
                 var inst = this.map.GetFeatureInstance(id);
-                this.map.UpdateFeatureInstance(inst.Translate(this.x, this.y));
+                this.map.UpdateFeatureInstanceInBatch(inst.Translate(this.x, this.y), this.ids);
             }
         }
 

--- a/Mappy/Program.cs
+++ b/Mappy/Program.cs
@@ -49,6 +49,8 @@
             var tileCache = new BitmapCache();
             var dialogService = new DialogService(mainForm);
             var featureService = new FeatureService();
+            FeatureInstance.FeatureService = featureService;
+
             var sectionsService = new SectionService();
             var sectionFactory = new SectionFactory(tileCache);
             var sectionBitmapService = new SectionBitmapService(sectionFactory);

--- a/Mappy/Services/Dispatcher.cs
+++ b/Mappy/Services/Dispatcher.cs
@@ -13,6 +13,7 @@
     using Mappy.Data;
     using Mappy.IO;
     using Mappy.Models;
+    using Mappy.Models.Enums;
     using Mappy.Util;
     using Mappy.Util.ImageSampling;
 
@@ -543,6 +544,11 @@
         public void SelectStartPosition(int index)
         {
             this.model.Map.IfSome(x => x.SelectStartPosition(index));
+        }
+
+        public void ChangeSelectedTab(GUITab tab)
+        {
+            this.model.SelectedGUITab = tab;
         }
 
         private static IEnumerable<string> GetMapNames(HpiArchive hpi)

--- a/Mappy/Services/Dispatcher.cs
+++ b/Mappy/Services/Dispatcher.cs
@@ -549,7 +549,7 @@
         public void ChangeSelectedTab(GUITab tab)
         {
             this.model.SelectedGUITab = tab;
-            this.model.Map.IfSome(x => x.UpdateSelectedGUITab(tab));
+            this.SetSelectedGUITabForMap();
         }
 
         private static IEnumerable<string> GetMapNames(HpiArchive hpi)
@@ -610,6 +610,11 @@
             }
 
             return false;
+        }
+
+        private void SetSelectedGUITabForMap()
+        {
+            this.model.Map.IfSome(x => x.UpdateSelectedGUITab(this.model.SelectedGUITab));
         }
 
         private void SaveHpi(UndoableMapModel map, string filename)
@@ -753,11 +758,13 @@
 
             var tntPath = HpiPath.Combine("maps", mapName + ".tnt");
             this.model.Map = Maybe.Some(this.mapLoadingService.CreateFromHpi(filename, tntPath, readOnly));
+            this.SetSelectedGUITabForMap();
         }
 
         private void OpenTnt(string filename)
         {
             this.model.Map = Maybe.Some(this.mapLoadingService.CreateFromTnt(filename));
+            this.SetSelectedGUITabForMap();
         }
 
         private bool CheckOkayDiscard()
@@ -789,7 +796,7 @@
         private void New(int width, int height)
         {
             this.model.Map = Maybe.Some(MapLoadingService.CreateMap(width, height));
-            this.model.Map.IfSome(x => x.UpdateSelectedGUITab(this.model.SelectedGUITab));
+            this.SetSelectedGUITabForMap();
         }
 
         private void OpenSct(string filename)

--- a/Mappy/Services/Dispatcher.cs
+++ b/Mappy/Services/Dispatcher.cs
@@ -789,6 +789,7 @@
         private void New(int width, int height)
         {
             this.model.Map = Maybe.Some(MapLoadingService.CreateMap(width, height));
+            this.model.Map.IfSome(x => x.UpdateSelectedGUITab(this.model.SelectedGUITab));
         }
 
         private void OpenSct(string filename)

--- a/Mappy/Services/Dispatcher.cs
+++ b/Mappy/Services/Dispatcher.cs
@@ -14,6 +14,7 @@
     using Mappy.IO;
     using Mappy.Models;
     using Mappy.Models.Enums;
+    using Mappy.UI.Controls;
     using Mappy.Util;
     using Mappy.Util.ImageSampling;
 
@@ -341,10 +342,28 @@
                         }
                         else
                         {
-                            var record = data as FeatureClipboardRecord;
-                            if (record != null)
+                            if (data is FeatureClipboardRecord record)
                             {
                                 map.DragDropFeature(record.FeatureName, loc.X, loc.Y);
+                                return;
+                            }
+
+                            if (data is List<FeatureClipboardRecord> featureList)
+                            {
+                                map.ClearSelection();
+                                var placedFeatures = new List<DrawableItem>();
+                                foreach (var feature in featureList)
+                                {
+                                    // Split these up so they can be debugged better
+                                    // force locs between 0 and MapWidth/Height
+                                    int xLocUnsafe = map.ViewportLocation.X + feature.VPOffsetX;
+                                    int xLoc = Math.Min(map.MapWidth * 32, Math.Max(0, xLocUnsafe));
+
+                                    int yLocUnsafe = map.ViewportLocation.Y + feature.VPOffsetY;
+                                    int yLoc = Math.Min(map.MapHeight * 32, Math.Max(0, yLocUnsafe));
+
+                                    map.DragDropFeature(feature.FeatureName, xLoc, yLoc, false);
+                                }
                             }
                         }
                     });
@@ -595,10 +614,26 @@
         {
             if (map.SelectedFeatures.Count > 0)
             {
-                var id = map.SelectedFeatures.First();
-                var inst = map.GetFeatureInstance(id);
-                var rec = new FeatureClipboardRecord(inst.FeatureName);
-                Clipboard.SetData(DataFormats.Serializable, rec);
+                if (map.SelectedFeatures.Count == 1)
+                {
+                    var id = map.SelectedFeatures.First();
+                    var inst = map.GetFeatureInstance(id);
+                    var rec = new FeatureClipboardRecord(inst.FeatureName);
+                    Clipboard.SetData(DataFormats.Serializable, rec);
+                    return true;
+                }
+
+                var loc = map.ViewportLocation;
+                var ids = map.SelectedFeatures.ToArray();
+                var features = new List<FeatureClipboardRecord>();
+
+                for (int i = 0; i < ids.Length; i++)
+                {
+                    var ins = map.GetFeatureInstance(ids[i]);
+                    features.Add(new FeatureClipboardRecord(ins.FeatureName, (ins.X * 16) - loc.X, (ins.Y * 16) - loc.Y));
+                }
+
+                Clipboard.SetData(DataFormats.Serializable, features);
                 return true;
             }
 

--- a/Mappy/Services/Dispatcher.cs
+++ b/Mappy/Services/Dispatcher.cs
@@ -549,6 +549,7 @@
         public void ChangeSelectedTab(GUITab tab)
         {
             this.model.SelectedGUITab = tab;
+            this.model.Map.IfSome(x => x.UpdateSelectedGUITab(tab));
         }
 
         private static IEnumerable<string> GetMapNames(HpiArchive hpi)

--- a/Mappy/UI/Forms/MainForm.Designer.cs
+++ b/Mappy/UI/Forms/MainForm.Designer.cs
@@ -86,19 +86,19 @@
             this.aboutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.sidebarTabs = new System.Windows.Forms.TabControl();
             this.sectionsTab = new System.Windows.Forms.TabPage();
+            this.sectionsView = new Mappy.UI.Controls.SectionView();
             this.featuresTab = new System.Windows.Forms.TabPage();
+            this.featureView = new Mappy.UI.Controls.SectionView();
             this.startPositionsTab = new System.Windows.Forms.TabPage();
+            this.startPositionsView1 = new Mappy.UI.Controls.StartPositionsView();
             this.attributesTab = new System.Windows.Forms.TabPage();
             this.seaLevelValueLabel = new System.Windows.Forms.Label();
             this.seaLevelLabel = new System.Windows.Forms.Label();
             this.seaLevelTrackbar = new System.Windows.Forms.TrackBar();
             this.statusStrip = new System.Windows.Forms.StatusStrip();
             this.mousePositionLabel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.mapViewPanel = new Mappy.UI.Controls.MapViewPanel();
-            this.sectionsView = new Mappy.UI.Controls.SectionView();
-            this.featureView = new Mappy.UI.Controls.SectionView();
-            this.startPositionsView1 = new Mappy.UI.Controls.StartPositionsView();
             this.hoveredFeatureLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.mapViewPanel = new Mappy.UI.Controls.MapViewPanel();
             toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
@@ -123,60 +123,62 @@
             // toolStripSeparator1
             // 
             toolStripSeparator1.Name = "toolStripSeparator1";
-            toolStripSeparator1.Size = new System.Drawing.Size(203, 6);
+            toolStripSeparator1.Size = new System.Drawing.Size(308, 6);
             // 
             // toolStripSeparator2
             // 
             toolStripSeparator2.Name = "toolStripSeparator2";
-            toolStripSeparator2.Size = new System.Drawing.Size(203, 6);
+            toolStripSeparator2.Size = new System.Drawing.Size(308, 6);
             // 
             // toolStripSeparator8
             // 
             toolStripSeparator8.Name = "toolStripSeparator8";
-            toolStripSeparator8.Size = new System.Drawing.Size(203, 6);
+            toolStripSeparator8.Size = new System.Drawing.Size(308, 6);
             // 
             // toolStripSeparator11
             // 
             toolStripSeparator11.Name = "toolStripSeparator11";
-            toolStripSeparator11.Size = new System.Drawing.Size(203, 6);
+            toolStripSeparator11.Size = new System.Drawing.Size(308, 6);
             // 
             // toolStripSeparator10
             // 
             toolStripSeparator10.Name = "toolStripSeparator10";
-            toolStripSeparator10.Size = new System.Drawing.Size(203, 6);
+            toolStripSeparator10.Size = new System.Drawing.Size(308, 6);
             // 
             // toolStripSeparator7
             // 
             toolStripSeparator7.Name = "toolStripSeparator7";
-            toolStripSeparator7.Size = new System.Drawing.Size(247, 6);
+            toolStripSeparator7.Size = new System.Drawing.Size(370, 6);
             // 
             // toolStripSeparator9
             // 
             toolStripSeparator9.Name = "toolStripSeparator9";
-            toolStripSeparator9.Size = new System.Drawing.Size(247, 6);
+            toolStripSeparator9.Size = new System.Drawing.Size(370, 6);
             // 
             // toolStripSeparator3
             // 
             toolStripSeparator3.Name = "toolStripSeparator3";
-            toolStripSeparator3.Size = new System.Drawing.Size(247, 6);
+            toolStripSeparator3.Size = new System.Drawing.Size(370, 6);
             // 
             // toolStripSeparator4
             // 
             toolStripSeparator4.Name = "toolStripSeparator4";
-            toolStripSeparator4.Size = new System.Drawing.Size(247, 6);
+            toolStripSeparator4.Size = new System.Drawing.Size(370, 6);
             // 
             // toolStripSeparator5
             // 
             toolStripSeparator5.Name = "toolStripSeparator5";
-            toolStripSeparator5.Size = new System.Drawing.Size(152, 6);
+            toolStripSeparator5.Size = new System.Drawing.Size(231, 6);
             // 
             // toolStripSeparator6
             // 
             toolStripSeparator6.Name = "toolStripSeparator6";
-            toolStripSeparator6.Size = new System.Drawing.Size(152, 6);
+            toolStripSeparator6.Size = new System.Drawing.Size(231, 6);
             // 
             // topMenu
             // 
+            this.topMenu.GripMargin = new System.Windows.Forms.Padding(2, 2, 0, 2);
+            this.topMenu.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.topMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileMenuItem,
             this.editMenuItem,
@@ -184,7 +186,7 @@
             this.helpMenuItem});
             this.topMenu.Location = new System.Drawing.Point(0, 0);
             this.topMenu.Name = "topMenu";
-            this.topMenu.Size = new System.Drawing.Size(784, 24);
+            this.topMenu.Size = new System.Drawing.Size(1176, 35);
             this.topMenu.TabIndex = 1;
             this.topMenu.Text = "menuStrip1";
             // 
@@ -209,14 +211,14 @@
             toolStripSeparator10,
             this.exitMenuItem});
             this.fileMenuItem.Name = "fileMenuItem";
-            this.fileMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileMenuItem.Size = new System.Drawing.Size(54, 29);
             this.fileMenuItem.Text = "&File";
             // 
             // newMenuItem
             // 
             this.newMenuItem.Name = "newMenuItem";
             this.newMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.newMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.newMenuItem.Size = new System.Drawing.Size(311, 34);
             this.newMenuItem.Text = "&New...";
             this.newMenuItem.Click += new System.EventHandler(this.NewMenuItemClick);
             // 
@@ -224,7 +226,7 @@
             // 
             this.openMenuItem.Name = "openMenuItem";
             this.openMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.openMenuItem.Size = new System.Drawing.Size(311, 34);
             this.openMenuItem.Text = "&Open...";
             this.openMenuItem.Click += new System.EventHandler(this.OpenMenuItemClick);
             // 
@@ -233,7 +235,7 @@
             this.saveMenuItem.Enabled = false;
             this.saveMenuItem.Name = "saveMenuItem";
             this.saveMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.saveMenuItem.Size = new System.Drawing.Size(311, 34);
             this.saveMenuItem.Text = "&Save";
             this.saveMenuItem.Click += new System.EventHandler(this.SaveMenuItemClick);
             // 
@@ -241,7 +243,7 @@
             // 
             this.saveAsMenuItem.Enabled = false;
             this.saveAsMenuItem.Name = "saveAsMenuItem";
-            this.saveAsMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.saveAsMenuItem.Size = new System.Drawing.Size(311, 34);
             this.saveAsMenuItem.Text = "Save &As...";
             this.saveAsMenuItem.Click += new System.EventHandler(this.SaveAsMenuItemClick);
             // 
@@ -250,7 +252,7 @@
             this.closeMenuItem.Enabled = false;
             this.closeMenuItem.Name = "closeMenuItem";
             this.closeMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.W)));
-            this.closeMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.closeMenuItem.Size = new System.Drawing.Size(311, 34);
             this.closeMenuItem.Text = "&Close";
             this.closeMenuItem.Click += new System.EventHandler(this.CloseMenuItemClick);
             // 
@@ -258,7 +260,7 @@
             // 
             this.importMinimapMenuItem.Enabled = false;
             this.importMinimapMenuItem.Name = "importMinimapMenuItem";
-            this.importMinimapMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.importMinimapMenuItem.Size = new System.Drawing.Size(311, 34);
             this.importMinimapMenuItem.Text = "Import Minimap...";
             this.importMinimapMenuItem.Click += new System.EventHandler(this.ImportMinimapMenuItemClick);
             // 
@@ -266,7 +268,7 @@
             // 
             this.importHeightmapMenuItem.Enabled = false;
             this.importHeightmapMenuItem.Name = "importHeightmapMenuItem";
-            this.importHeightmapMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.importHeightmapMenuItem.Size = new System.Drawing.Size(311, 34);
             this.importHeightmapMenuItem.Text = "Import Heightmap...";
             this.importHeightmapMenuItem.Click += new System.EventHandler(this.ImportHeightmapMenuItemClick);
             // 
@@ -274,7 +276,7 @@
             // 
             this.importCustomSectionMenuItem.Enabled = false;
             this.importCustomSectionMenuItem.Name = "importCustomSectionMenuItem";
-            this.importCustomSectionMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.importCustomSectionMenuItem.Size = new System.Drawing.Size(311, 34);
             this.importCustomSectionMenuItem.Text = "Import Custom Section...";
             this.importCustomSectionMenuItem.Click += new System.EventHandler(this.ImportCustomSectionMenuItemClick);
             // 
@@ -282,7 +284,7 @@
             // 
             this.exportMinimapMenuItem.Enabled = false;
             this.exportMinimapMenuItem.Name = "exportMinimapMenuItem";
-            this.exportMinimapMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.exportMinimapMenuItem.Size = new System.Drawing.Size(311, 34);
             this.exportMinimapMenuItem.Text = "Export Minimap...";
             this.exportMinimapMenuItem.Click += new System.EventHandler(this.ExportMinimapMenuItemClick);
             // 
@@ -290,7 +292,7 @@
             // 
             this.exportHeightmapMenuItem.Enabled = false;
             this.exportHeightmapMenuItem.Name = "exportHeightmapMenuItem";
-            this.exportHeightmapMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.exportHeightmapMenuItem.Size = new System.Drawing.Size(311, 34);
             this.exportHeightmapMenuItem.Text = "Export Heightmap...";
             this.exportHeightmapMenuItem.Click += new System.EventHandler(this.ExportHeightmapMenuItemClick);
             // 
@@ -298,14 +300,14 @@
             // 
             this.exportMapImageMenuItem.Enabled = false;
             this.exportMapImageMenuItem.Name = "exportMapImageMenuItem";
-            this.exportMapImageMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.exportMapImageMenuItem.Size = new System.Drawing.Size(311, 34);
             this.exportMapImageMenuItem.Text = "Export Map Image...";
             this.exportMapImageMenuItem.Click += new System.EventHandler(this.ExportMapImageMenuItemClick);
             // 
             // exitMenuItem
             // 
             this.exitMenuItem.Name = "exitMenuItem";
-            this.exitMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.exitMenuItem.Size = new System.Drawing.Size(311, 34);
             this.exitMenuItem.Text = "E&xit";
             this.exitMenuItem.Click += new System.EventHandler(this.ExitMenuItemClick);
             // 
@@ -326,7 +328,7 @@
             toolStripSeparator4,
             this.preferencesMenuItem});
             this.editMenuItem.Name = "editMenuItem";
-            this.editMenuItem.Size = new System.Drawing.Size(39, 20);
+            this.editMenuItem.Size = new System.Drawing.Size(58, 29);
             this.editMenuItem.Text = "&Edit";
             // 
             // undoMenuItem
@@ -334,7 +336,7 @@
             this.undoMenuItem.Enabled = false;
             this.undoMenuItem.Name = "undoMenuItem";
             this.undoMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-            this.undoMenuItem.Size = new System.Drawing.Size(250, 22);
+            this.undoMenuItem.Size = new System.Drawing.Size(373, 34);
             this.undoMenuItem.Text = "&Undo";
             this.undoMenuItem.Click += new System.EventHandler(this.UndoMenuItemClick);
             // 
@@ -343,7 +345,7 @@
             this.redoMenuItem.Enabled = false;
             this.redoMenuItem.Name = "redoMenuItem";
             this.redoMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
-            this.redoMenuItem.Size = new System.Drawing.Size(250, 22);
+            this.redoMenuItem.Size = new System.Drawing.Size(373, 34);
             this.redoMenuItem.Text = "&Redo";
             this.redoMenuItem.Click += new System.EventHandler(this.RedoMenuItemClick);
             // 
@@ -352,7 +354,7 @@
             this.cutMenuItem.Enabled = false;
             this.cutMenuItem.Name = "cutMenuItem";
             this.cutMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-            this.cutMenuItem.Size = new System.Drawing.Size(250, 22);
+            this.cutMenuItem.Size = new System.Drawing.Size(373, 34);
             this.cutMenuItem.Text = "Cut";
             this.cutMenuItem.Click += new System.EventHandler(this.CutMenuItemClick);
             // 
@@ -361,7 +363,7 @@
             this.copyMenuItem.Enabled = false;
             this.copyMenuItem.Name = "copyMenuItem";
             this.copyMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyMenuItem.Size = new System.Drawing.Size(250, 22);
+            this.copyMenuItem.Size = new System.Drawing.Size(373, 34);
             this.copyMenuItem.Text = "Copy";
             this.copyMenuItem.Click += new System.EventHandler(this.CopyMenuItemClick);
             // 
@@ -370,7 +372,7 @@
             this.pasteMenuItem.Enabled = false;
             this.pasteMenuItem.Name = "pasteMenuItem";
             this.pasteMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this.pasteMenuItem.Size = new System.Drawing.Size(250, 22);
+            this.pasteMenuItem.Size = new System.Drawing.Size(373, 34);
             this.pasteMenuItem.Text = "Paste";
             this.pasteMenuItem.Click += new System.EventHandler(this.PasteMenuItemClick);
             // 
@@ -378,7 +380,7 @@
             // 
             this.mapAttributesMenuItem.Enabled = false;
             this.mapAttributesMenuItem.Name = "mapAttributesMenuItem";
-            this.mapAttributesMenuItem.Size = new System.Drawing.Size(250, 22);
+            this.mapAttributesMenuItem.Size = new System.Drawing.Size(373, 34);
             this.mapAttributesMenuItem.Text = "Map Attributes...";
             this.mapAttributesMenuItem.Click += new System.EventHandler(this.MapAttributesMenuItemClick);
             // 
@@ -387,7 +389,7 @@
             this.generateMinimapMenuItem.Enabled = false;
             this.generateMinimapMenuItem.Name = "generateMinimapMenuItem";
             this.generateMinimapMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G)));
-            this.generateMinimapMenuItem.Size = new System.Drawing.Size(250, 22);
+            this.generateMinimapMenuItem.Size = new System.Drawing.Size(373, 34);
             this.generateMinimapMenuItem.Text = "&Generate Minimap";
             this.generateMinimapMenuItem.Click += new System.EventHandler(this.GenerateMinimapMenuItemClick);
             // 
@@ -395,7 +397,7 @@
             // 
             this.generateMinimapHighQualityMenuItem.Enabled = false;
             this.generateMinimapHighQualityMenuItem.Name = "generateMinimapHighQualityMenuItem";
-            this.generateMinimapHighQualityMenuItem.Size = new System.Drawing.Size(250, 22);
+            this.generateMinimapHighQualityMenuItem.Size = new System.Drawing.Size(373, 34);
             this.generateMinimapHighQualityMenuItem.Text = "Generate Minimap (High Quality)";
             this.generateMinimapHighQualityMenuItem.Click += new System.EventHandler(this.GenerateMinimapHighQualityMenuItemClick);
             // 
@@ -403,7 +405,7 @@
             // 
             this.preferencesMenuItem.Name = "preferencesMenuItem";
             this.preferencesMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
-            this.preferencesMenuItem.Size = new System.Drawing.Size(250, 22);
+            this.preferencesMenuItem.Size = new System.Drawing.Size(373, 34);
             this.preferencesMenuItem.Text = "&Preferences...";
             this.preferencesMenuItem.Click += new System.EventHandler(this.PreferencesMenuItemClick);
             // 
@@ -417,21 +419,21 @@
             this.gridMenuItem,
             this.toggleFeaturesMenuItem});
             this.viewMenuItem.Name = "viewMenuItem";
-            this.viewMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.viewMenuItem.Size = new System.Drawing.Size(65, 29);
             this.viewMenuItem.Text = "&View";
             // 
             // toggleHeightmapMenuItem
             // 
             this.toggleHeightmapMenuItem.Name = "toggleHeightmapMenuItem";
             this.toggleHeightmapMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.H)));
-            this.toggleHeightmapMenuItem.Size = new System.Drawing.Size(229, 22);
+            this.toggleHeightmapMenuItem.Size = new System.Drawing.Size(345, 34);
             this.toggleHeightmapMenuItem.Text = "&Heightmap Contours";
             this.toggleHeightmapMenuItem.Click += new System.EventHandler(this.ToggleHeightmapMenuItemClick);
             // 
             // toggleHeightGridMenuItem
             // 
             this.toggleHeightGridMenuItem.Name = "toggleHeightGridMenuItem";
-            this.toggleHeightGridMenuItem.Size = new System.Drawing.Size(229, 22);
+            this.toggleHeightGridMenuItem.Size = new System.Drawing.Size(345, 34);
             this.toggleHeightGridMenuItem.Text = "Heightmap &Grid";
             this.toggleHeightGridMenuItem.Click += new System.EventHandler(this.ToggleHeightGridMenuItemClick);
             // 
@@ -439,14 +441,14 @@
             // 
             this.toggleMinimapMenuItem.Name = "toggleMinimapMenuItem";
             this.toggleMinimapMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.M)));
-            this.toggleMinimapMenuItem.Size = new System.Drawing.Size(229, 22);
+            this.toggleMinimapMenuItem.Size = new System.Drawing.Size(345, 34);
             this.toggleMinimapMenuItem.Text = "&Minimap";
             this.toggleMinimapMenuItem.Click += new System.EventHandler(this.ToggleMinimapMenuItemClick);
             // 
             // toggleVoidsMenuItem
             // 
             this.toggleVoidsMenuItem.Name = "toggleVoidsMenuItem";
-            this.toggleVoidsMenuItem.Size = new System.Drawing.Size(229, 22);
+            this.toggleVoidsMenuItem.Size = new System.Drawing.Size(345, 34);
             this.toggleVoidsMenuItem.Text = "Voids";
             this.toggleVoidsMenuItem.Click += new System.EventHandler(this.ToggleVoidsMenuItemClick);
             // 
@@ -465,7 +467,7 @@
             toolStripSeparator6,
             this.gridColorMenuItem});
             this.gridMenuItem.Name = "gridMenuItem";
-            this.gridMenuItem.Size = new System.Drawing.Size(229, 22);
+            this.gridMenuItem.Size = new System.Drawing.Size(345, 34);
             this.gridMenuItem.Text = "Grid";
             // 
             // gridOffMenuItem
@@ -473,7 +475,7 @@
             this.gridOffMenuItem.Checked = true;
             this.gridOffMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.gridOffMenuItem.Name = "gridOffMenuItem";
-            this.gridOffMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.gridOffMenuItem.Size = new System.Drawing.Size(234, 34);
             this.gridOffMenuItem.Tag = "0";
             this.gridOffMenuItem.Text = "Off";
             this.gridOffMenuItem.Click += new System.EventHandler(this.GridOffMenuItemClick);
@@ -481,7 +483,7 @@
             // grid16MenuItem
             // 
             this.grid16MenuItem.Name = "grid16MenuItem";
-            this.grid16MenuItem.Size = new System.Drawing.Size(155, 22);
+            this.grid16MenuItem.Size = new System.Drawing.Size(234, 34);
             this.grid16MenuItem.Tag = "16";
             this.grid16MenuItem.Text = "16x16";
             this.grid16MenuItem.Click += new System.EventHandler(this.GridMenuItemClick);
@@ -489,7 +491,7 @@
             // grid32MenuItem
             // 
             this.grid32MenuItem.Name = "grid32MenuItem";
-            this.grid32MenuItem.Size = new System.Drawing.Size(155, 22);
+            this.grid32MenuItem.Size = new System.Drawing.Size(234, 34);
             this.grid32MenuItem.Tag = "32";
             this.grid32MenuItem.Text = "32x32";
             this.grid32MenuItem.Click += new System.EventHandler(this.GridMenuItemClick);
@@ -497,7 +499,7 @@
             // grid64MenuItem
             // 
             this.grid64MenuItem.Name = "grid64MenuItem";
-            this.grid64MenuItem.Size = new System.Drawing.Size(155, 22);
+            this.grid64MenuItem.Size = new System.Drawing.Size(234, 34);
             this.grid64MenuItem.Tag = "64";
             this.grid64MenuItem.Text = "64x64";
             this.grid64MenuItem.Click += new System.EventHandler(this.GridMenuItemClick);
@@ -505,7 +507,7 @@
             // grid128MenuItem
             // 
             this.grid128MenuItem.Name = "grid128MenuItem";
-            this.grid128MenuItem.Size = new System.Drawing.Size(155, 22);
+            this.grid128MenuItem.Size = new System.Drawing.Size(234, 34);
             this.grid128MenuItem.Tag = "128";
             this.grid128MenuItem.Text = "128x128";
             this.grid128MenuItem.Click += new System.EventHandler(this.GridMenuItemClick);
@@ -513,7 +515,7 @@
             // grid256MenuItem
             // 
             this.grid256MenuItem.Name = "grid256MenuItem";
-            this.grid256MenuItem.Size = new System.Drawing.Size(155, 22);
+            this.grid256MenuItem.Size = new System.Drawing.Size(234, 34);
             this.grid256MenuItem.Tag = "256";
             this.grid256MenuItem.Text = "256x256";
             this.grid256MenuItem.Click += new System.EventHandler(this.GridMenuItemClick);
@@ -521,7 +523,7 @@
             // grid512MenuItem
             // 
             this.grid512MenuItem.Name = "grid512MenuItem";
-            this.grid512MenuItem.Size = new System.Drawing.Size(155, 22);
+            this.grid512MenuItem.Size = new System.Drawing.Size(234, 34);
             this.grid512MenuItem.Tag = "512";
             this.grid512MenuItem.Text = "512x512";
             this.grid512MenuItem.Click += new System.EventHandler(this.GridMenuItemClick);
@@ -529,7 +531,7 @@
             // grid1024MenuItem
             // 
             this.grid1024MenuItem.Name = "grid1024MenuItem";
-            this.grid1024MenuItem.Size = new System.Drawing.Size(155, 22);
+            this.grid1024MenuItem.Size = new System.Drawing.Size(234, 34);
             this.grid1024MenuItem.Tag = "1024";
             this.grid1024MenuItem.Text = "1024x1024";
             this.grid1024MenuItem.Click += new System.EventHandler(this.GridMenuItemClick);
@@ -537,7 +539,7 @@
             // gridColorMenuItem
             // 
             this.gridColorMenuItem.Name = "gridColorMenuItem";
-            this.gridColorMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.gridColorMenuItem.Size = new System.Drawing.Size(234, 34);
             this.gridColorMenuItem.Text = "Choose Color...";
             this.gridColorMenuItem.Click += new System.EventHandler(this.GridColorMenuItemClick);
             // 
@@ -546,7 +548,7 @@
             this.toggleFeaturesMenuItem.Checked = true;
             this.toggleFeaturesMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.toggleFeaturesMenuItem.Name = "toggleFeaturesMenuItem";
-            this.toggleFeaturesMenuItem.Size = new System.Drawing.Size(229, 22);
+            this.toggleFeaturesMenuItem.Size = new System.Drawing.Size(345, 34);
             this.toggleFeaturesMenuItem.Text = "Features";
             this.toggleFeaturesMenuItem.Click += new System.EventHandler(this.ToggleFeaturesMenuItemClick);
             // 
@@ -555,13 +557,13 @@
             this.helpMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutMenuItem});
             this.helpMenuItem.Name = "helpMenuItem";
-            this.helpMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpMenuItem.Size = new System.Drawing.Size(65, 29);
             this.helpMenuItem.Text = "&Help";
             // 
             // aboutMenuItem
             // 
             this.aboutMenuItem.Name = "aboutMenuItem";
-            this.aboutMenuItem.Size = new System.Drawing.Size(116, 22);
+            this.aboutMenuItem.Size = new System.Drawing.Size(176, 34);
             this.aboutMenuItem.Text = "&About...";
             this.aboutMenuItem.Click += new System.EventHandler(this.AboutMenuItemClick);
             // 
@@ -572,55 +574,88 @@
             this.sidebarTabs.Controls.Add(this.startPositionsTab);
             this.sidebarTabs.Controls.Add(this.attributesTab);
             this.sidebarTabs.Dock = System.Windows.Forms.DockStyle.Left;
-            this.sidebarTabs.Location = new System.Drawing.Point(0, 24);
+            this.sidebarTabs.Location = new System.Drawing.Point(0, 35);
+            this.sidebarTabs.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.sidebarTabs.Name = "sidebarTabs";
             this.sidebarTabs.SelectedIndex = 0;
-            this.sidebarTabs.Size = new System.Drawing.Size(215, 538);
+            this.sidebarTabs.Size = new System.Drawing.Size(322, 830);
             this.sidebarTabs.TabIndex = 4;
+            this.sidebarTabs.SelectedIndexChanged += new System.EventHandler(this.GUITabs_SelectedIndexChanged);
             // 
             // sectionsTab
             // 
             this.sectionsTab.Controls.Add(this.sectionsView);
-            this.sectionsTab.Location = new System.Drawing.Point(4, 22);
+            this.sectionsTab.Location = new System.Drawing.Point(4, 29);
+            this.sectionsTab.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.sectionsTab.Name = "sectionsTab";
-            this.sectionsTab.Padding = new System.Windows.Forms.Padding(3);
-            this.sectionsTab.Size = new System.Drawing.Size(207, 512);
+            this.sectionsTab.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.sectionsTab.Size = new System.Drawing.Size(314, 797);
             this.sectionsTab.TabIndex = 0;
             this.sectionsTab.Text = "Sections";
             this.sectionsTab.UseVisualStyleBackColor = true;
             // 
+            // sectionsView
+            // 
+            this.sectionsView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.sectionsView.ImageSize = new System.Drawing.Size(128, 128);
+            this.sectionsView.Location = new System.Drawing.Point(4, 5);
+            this.sectionsView.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.sectionsView.Name = "sectionsView";
+            this.sectionsView.Size = new System.Drawing.Size(306, 787);
+            this.sectionsView.TabIndex = 3;
+            // 
             // featuresTab
             // 
             this.featuresTab.Controls.Add(this.featureView);
-            this.featuresTab.Location = new System.Drawing.Point(4, 22);
+            this.featuresTab.Location = new System.Drawing.Point(4, 29);
+            this.featuresTab.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.featuresTab.Name = "featuresTab";
-            this.featuresTab.Padding = new System.Windows.Forms.Padding(3);
-            this.featuresTab.Size = new System.Drawing.Size(207, 512);
+            this.featuresTab.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.featuresTab.Size = new System.Drawing.Size(314, 797);
             this.featuresTab.TabIndex = 1;
             this.featuresTab.Text = "Features";
             this.featuresTab.UseVisualStyleBackColor = true;
             // 
+            // featureView
+            // 
+            this.featureView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.featureView.ImageSize = new System.Drawing.Size(64, 64);
+            this.featureView.Location = new System.Drawing.Point(4, 5);
+            this.featureView.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.featureView.Name = "featureView";
+            this.featureView.Size = new System.Drawing.Size(306, 787);
+            this.featureView.TabIndex = 0;
+            // 
             // startPositionsTab
             // 
             this.startPositionsTab.Controls.Add(this.startPositionsView1);
-            this.startPositionsTab.Location = new System.Drawing.Point(4, 22);
+            this.startPositionsTab.Location = new System.Drawing.Point(4, 29);
+            this.startPositionsTab.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.startPositionsTab.Name = "startPositionsTab";
-            this.startPositionsTab.Padding = new System.Windows.Forms.Padding(3);
-            this.startPositionsTab.Size = new System.Drawing.Size(207, 512);
+            this.startPositionsTab.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.startPositionsTab.Size = new System.Drawing.Size(314, 797);
             this.startPositionsTab.TabIndex = 2;
             this.startPositionsTab.Text = "Starts";
             this.startPositionsTab.UseVisualStyleBackColor = true;
+            // 
+            // startPositionsView1
+            // 
+            this.startPositionsView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.startPositionsView1.Location = new System.Drawing.Point(4, 5);
+            this.startPositionsView1.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.startPositionsView1.Name = "startPositionsView1";
+            this.startPositionsView1.Size = new System.Drawing.Size(306, 787);
+            this.startPositionsView1.TabIndex = 0;
             // 
             // attributesTab
             // 
             this.attributesTab.Controls.Add(this.seaLevelValueLabel);
             this.attributesTab.Controls.Add(this.seaLevelLabel);
             this.attributesTab.Controls.Add(this.seaLevelTrackbar);
-            this.attributesTab.Location = new System.Drawing.Point(4, 22);
-            this.attributesTab.Margin = new System.Windows.Forms.Padding(2);
+            this.attributesTab.Location = new System.Drawing.Point(4, 29);
             this.attributesTab.Name = "attributesTab";
-            this.attributesTab.Padding = new System.Windows.Forms.Padding(2);
-            this.attributesTab.Size = new System.Drawing.Size(207, 512);
+            this.attributesTab.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.attributesTab.Size = new System.Drawing.Size(314, 795);
             this.attributesTab.TabIndex = 3;
             this.attributesTab.Text = "Attributes";
             this.attributesTab.UseVisualStyleBackColor = true;
@@ -629,10 +664,9 @@
             // 
             this.seaLevelValueLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.seaLevelValueLabel.Enabled = false;
-            this.seaLevelValueLabel.Location = new System.Drawing.Point(173, 5);
-            this.seaLevelValueLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.seaLevelValueLabel.Location = new System.Drawing.Point(260, 8);
             this.seaLevelValueLabel.Name = "seaLevelValueLabel";
-            this.seaLevelValueLabel.Size = new System.Drawing.Size(32, 14);
+            this.seaLevelValueLabel.Size = new System.Drawing.Size(48, 22);
             this.seaLevelValueLabel.TabIndex = 10;
             this.seaLevelValueLabel.Text = "0";
             this.seaLevelValueLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -641,10 +675,9 @@
             // 
             this.seaLevelLabel.AutoSize = true;
             this.seaLevelLabel.Enabled = false;
-            this.seaLevelLabel.Location = new System.Drawing.Point(4, 5);
-            this.seaLevelLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.seaLevelLabel.Location = new System.Drawing.Point(6, 8);
             this.seaLevelLabel.Name = "seaLevelLabel";
-            this.seaLevelLabel.Size = new System.Drawing.Size(55, 13);
+            this.seaLevelLabel.Size = new System.Drawing.Size(79, 20);
             this.seaLevelLabel.TabIndex = 9;
             this.seaLevelLabel.Text = "Sea Level";
             // 
@@ -653,11 +686,10 @@
             this.seaLevelTrackbar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.seaLevelTrackbar.Enabled = false;
-            this.seaLevelTrackbar.Location = new System.Drawing.Point(62, 5);
-            this.seaLevelTrackbar.Margin = new System.Windows.Forms.Padding(2);
+            this.seaLevelTrackbar.Location = new System.Drawing.Point(93, 8);
             this.seaLevelTrackbar.Maximum = 255;
             this.seaLevelTrackbar.Name = "seaLevelTrackbar";
-            this.seaLevelTrackbar.Size = new System.Drawing.Size(106, 45);
+            this.seaLevelTrackbar.Size = new System.Drawing.Size(159, 69);
             this.seaLevelTrackbar.TabIndex = 8;
             this.seaLevelTrackbar.TickFrequency = 16;
             this.seaLevelTrackbar.ValueChanged += new System.EventHandler(this.SeaLevelTrackBarValueChanged);
@@ -665,76 +697,51 @@
             // 
             // statusStrip
             // 
+            this.statusStrip.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mousePositionLabel,
             this.hoveredFeatureLabel});
-            this.statusStrip.Location = new System.Drawing.Point(215, 540);
+            this.statusStrip.Location = new System.Drawing.Point(322, 833);
             this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(569, 22);
+            this.statusStrip.Padding = new System.Windows.Forms.Padding(2, 0, 21, 0);
+            this.statusStrip.Size = new System.Drawing.Size(854, 32);
             this.statusStrip.TabIndex = 6;
             this.statusStrip.Text = "statusStrip1";
             // 
             // mousePositionLabel
             // 
             this.mousePositionLabel.Name = "mousePositionLabel";
-            this.mousePositionLabel.Size = new System.Drawing.Size(49, 17);
+            this.mousePositionLabel.Size = new System.Drawing.Size(74, 25);
             this.mousePositionLabel.Text = "X: -, Y: -";
-            // 
-            // mapViewPanel
-            // 
-            this.mapViewPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.mapViewPanel.Location = new System.Drawing.Point(215, 24);
-            this.mapViewPanel.Name = "mapViewPanel";
-            this.mapViewPanel.Size = new System.Drawing.Size(569, 516);
-            this.mapViewPanel.TabIndex = 5;
-            // 
-            // sectionsView
-            // 
-            this.sectionsView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.sectionsView.ImageSize = new System.Drawing.Size(128, 128);
-            this.sectionsView.Location = new System.Drawing.Point(3, 3);
-            this.sectionsView.Margin = new System.Windows.Forms.Padding(4);
-            this.sectionsView.Name = "sectionsView";
-            this.sectionsView.Size = new System.Drawing.Size(201, 506);
-            this.sectionsView.TabIndex = 3;
-            // 
-            // featureView
-            // 
-            this.featureView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.featureView.ImageSize = new System.Drawing.Size(64, 64);
-            this.featureView.Location = new System.Drawing.Point(3, 3);
-            this.featureView.Margin = new System.Windows.Forms.Padding(4);
-            this.featureView.Name = "featureView";
-            this.featureView.Size = new System.Drawing.Size(201, 506);
-            this.featureView.TabIndex = 0;
-            // 
-            // startPositionsView1
-            // 
-            this.startPositionsView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.startPositionsView1.Location = new System.Drawing.Point(3, 3);
-            this.startPositionsView1.Margin = new System.Windows.Forms.Padding(4);
-            this.startPositionsView1.Name = "startPositionsView1";
-            this.startPositionsView1.Size = new System.Drawing.Size(201, 506);
-            this.startPositionsView1.TabIndex = 0;
             // 
             // hoveredFeatureLabel
             // 
             this.hoveredFeatureLabel.Name = "hoveredFeatureLabel";
-            this.hoveredFeatureLabel.Size = new System.Drawing.Size(22, 17);
+            this.hoveredFeatureLabel.Size = new System.Drawing.Size(33, 25);
             this.hoveredFeatureLabel.Text = "---";
+            // 
+            // mapViewPanel
+            // 
+            this.mapViewPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.mapViewPanel.Location = new System.Drawing.Point(322, 35);
+            this.mapViewPanel.Margin = new System.Windows.Forms.Padding(6, 8, 6, 8);
+            this.mapViewPanel.Name = "mapViewPanel";
+            this.mapViewPanel.Size = new System.Drawing.Size(854, 798);
+            this.mapViewPanel.TabIndex = 5;
             // 
             // MainForm
             // 
             this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(784, 562);
+            this.ClientSize = new System.Drawing.Size(1176, 865);
             this.Controls.Add(this.mapViewPanel);
             this.Controls.Add(this.statusStrip);
             this.Controls.Add(this.sidebarTabs);
             this.Controls.Add(this.topMenu);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.topMenu;
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "MainForm";
             this.Text = "Mappy";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainFormFormClosing);

--- a/Mappy/UI/Forms/MainForm.cs
+++ b/Mappy/UI/Forms/MainForm.cs
@@ -7,8 +7,8 @@
     using System.Windows.Forms;
 
     using Mappy.Models;
-    using Mappy.Models.Enums;
     using Mappy.UI.Controls;
+    using Mappy.Util;
 
     public partial class MainForm : Form
     {
@@ -303,24 +303,7 @@
                 return;
             }
 
-            this.model.ChangeSelectedTabType(this.MapTabNameToGUIType(this.sidebarTabs.SelectedTab.Name));
-        }
-
-        private GUITab MapTabNameToGUIType(string tabName)
-        {
-            switch (tabName)
-            {
-                case "sectionsTab":
-                    return GUITab.Sections;
-                case "featuresTab":
-                    return GUITab.Features;
-                case "attributesTab":
-                    return GUITab.Attributes;
-                case "startPositionsTab":
-                    return GUITab.Starts;
-                default:
-                    return GUITab.Other;
-            }
+            this.model.ChangeSelectedTabType(Util.MapTabNameToGUIType(this.sidebarTabs.SelectedTab.Name));
         }
     }
 }

--- a/Mappy/UI/Forms/MainForm.cs
+++ b/Mappy/UI/Forms/MainForm.cs
@@ -294,5 +294,15 @@
         {
             this.model.ToggleHeightGridMenuItemClick();
         }
+
+        private void GUITabs_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (this.sidebarTabs.SelectedTab == null)
+            {
+                return;
+            }
+
+            //this.model.ChangeSelectedTab(this.sidebarTabs);
+        }
     }
 }

--- a/Mappy/UI/Forms/MainForm.cs
+++ b/Mappy/UI/Forms/MainForm.cs
@@ -7,6 +7,7 @@
     using System.Windows.Forms;
 
     using Mappy.Models;
+    using Mappy.Models.Enums;
     using Mappy.UI.Controls;
 
     public partial class MainForm : Form
@@ -302,7 +303,24 @@
                 return;
             }
 
-            //this.model.ChangeSelectedTab(this.sidebarTabs);
+            this.model.ChangeSelectedTabType(this.MapTabNameToGUIType(this.sidebarTabs.SelectedTab.Name));
+        }
+
+        private GUITab MapTabNameToGUIType(string tabName)
+        {
+            switch (tabName)
+            {
+                case "sectionsTab":
+                    return GUITab.Sections;
+                case "featuresTab":
+                    return GUITab.Features;
+                case "attributesTab":
+                    return GUITab.Attributes;
+                case "startPositionsTab":
+                    return GUITab.Starts;
+                default:
+                    return GUITab.Other;
+            }
         }
     }
 }

--- a/Mappy/Util/Util.cs
+++ b/Mappy/Util/Util.cs
@@ -14,6 +14,7 @@ namespace Mappy.Util
     using Mappy.Collections;
     using Mappy.Data;
     using Mappy.Models;
+    using Mappy.Models.Enums;
     using Mappy.Properties;
     using Mappy.Services;
     using Mappy.Util.ImageSampling;
@@ -172,6 +173,7 @@ namespace Mappy.Util
         public struct FeatureInfo
         {
             public Bitmap Image { get; set; }
+
             public Point Location { get; set; }
         }
 
@@ -187,10 +189,10 @@ namespace Mappy.Util
                     args.FeatureService.TryGetFeature(f.FeatureName)
                         .Where(rec => rec.Permanent)
                         .Select(rec => new FeatureInfo
-                            {
-                                Image = rec.Image,
-                                Location = rec.GetDrawBounds(args.MapModel.Tile.HeightGrid, f.X, f.Y).Location
-                            }))
+                        {
+                            Image = rec.Image,
+                            Location = rec.GetDrawBounds(args.MapModel.Tile.HeightGrid, f.X, f.Y).Location
+                        }))
                 .ToList();
             featuresList.Sort((a, b) =>
             {
@@ -487,6 +489,23 @@ namespace Mappy.Util
         public static GridCoordinates ToGridCoordinates(Point p)
         {
             return new GridCoordinates(p.X, p.Y);
+        }
+
+        public static GUITab MapTabNameToGUIType(string tabName)
+        {
+            switch (tabName)
+            {
+                case "sectionsTab":
+                    return GUITab.Sections;
+                case "featuresTab":
+                    return GUITab.Features;
+                case "attributesTab":
+                    return GUITab.Attributes;
+                case "startPositionsTab":
+                    return GUITab.Starts;
+                default:
+                    return GUITab.Other;
+            }
         }
 
         public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue defaultValue)


### PR DESCRIPTION
Builds upon #14 feature bandbox

### Main Functionality

Add ability to copy and paste multiple features selected by bandbox selection. The paste operation is safe and will only place features that are not blocked.

### Functional Requirements:
- Single Features copy&paste is unchanged and behaves as usual.
- Section tile copy&paste is unchanged and behaves as usual.
- Multiple Features selected are copied without issue.
- Multiple copied Features retain their relative offsets when pasted.
- Features that would be pasted with an invalid relative offset (e.g. offset would place feature off-map) are not placed and do not cause an error.
- All of the multiple pasted Features remain selected.